### PR TITLE
Fix cooldown update and balance synchronization issues

### DIFF
--- a/app/core.py
+++ b/app/core.py
@@ -457,7 +457,7 @@ def sync_balance():
             # Ensure we have the latest prev_balance.
             credit_account.prev_balance = refreshed.prev_balance
             if (credit_account.pot_id):
-                live = credit_account.get_total_balance(force_refresh=True)
+                live = credit_account.get_total_balance(force_refresh=False)
                 prev = credit_account.get_prev_balance(credit_account.pot_id)
                 if (credit_account.cooldown_until and current_time < credit_account.cooldown_until):
                     log.info(f"[Baseline Update] {credit_account.type}: Cooldown active; baseline not updated.")

--- a/app/web/settings.py
+++ b/app/web/settings.py
@@ -69,6 +69,7 @@ def clear_cooldown():
         except Exception:
             new_baseline = account.get_total_balance()
         account.prev_balance = new_baseline
-        account_repository.save(account)
+        # Explicitly update cooldown field in the database
+        account_repository.update_credit_account_fields(account.type, account.pot_id, new_baseline, None)
     flash("Cooldown cleared—baseline updated for selected account(s).")
     return redirect(url_for("settings.index"))


### PR DESCRIPTION
Update the cooldown field in the database when clearing cooldown and prevent forced refresh during total balance retrieval.